### PR TITLE
Add support for recurring_application_charges/customize

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ shopify.metafield.create({
   - `delete(id)`
   - `get(id[, params])`
   - `list([params])`
+  - `customize(id, cappedAmount)`
 - redirect
   - `count([params])`
   - `create(params)`

--- a/resources/recurring-application-charge.js
+++ b/resources/recurring-application-charge.js
@@ -42,7 +42,7 @@ RecurringApplicationCharge.prototype.activate = function activate(id, params) {
  * Customize a recurring application charge (increase the capped amount)
  *
  * @param {Number} id Recurring application charge ID
- * @param {Object} params Recurring application charge properties
+ * @param {Number} cappedAmount The new capped amount to apply to the recurring application charge
  * @return {Promise} Promise that resolves with the result
  * @public
  */

--- a/resources/recurring-application-charge.js
+++ b/resources/recurring-application-charge.js
@@ -38,4 +38,18 @@ RecurringApplicationCharge.prototype.activate = function activate(id, params) {
     .then(body => body[this.key]);
 };
 
+/**
+ * Customize a recurring application charge (increase the capped amount)
+ *
+ * @param {Number} id Recurring application charge ID
+ * @param {Object} params Recurring application charge properties
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+RecurringApplicationCharge.prototype.customize = function customize(id, cappedAmount) {
+  const url = this.buildUrl(`${id}/customize`, { 'recurring_application_charge[capped_amount]': cappedAmount });
+  return this.shopify.request(url, 'PUT')
+    .then(body => body[this.key]);
+};
+
 module.exports = RecurringApplicationCharge;


### PR DESCRIPTION
Support missing recurringApplicationCharge endpoint: customize.

This is used to increase the capped amount for a recurring charge.